### PR TITLE
Move deployments to `production` branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     },
     "scripts": {
-        "build": "./vendor/bin/jigsaw build"
+        "build": "./vendor/bin/jigsaw build",
+        "deploy": "./tasks/deploy.sh"
     }
 }

--- a/tasks/deploy.sh
+++ b/tasks/deploy.sh
@@ -1,6 +1,36 @@
 #!/usr/bin/env bash
 
+# git reset HEAD^ # start by resetting against HEAD
+
+version_file=./.version # change this to your desired version file
+source_branch=master
+production_branch=production
+author_string="Ryan's Deployment Script <deployments@ryangjchandler.co.uk>"
+new_tag_date=$(date +"%Y-%m-%d %H-%M-%S")
+new_tag=$(date +"%Y%m%d%H%M%S") # set a new tag for the deployment
+
+echo "Previous deployment: $(git describe --abbrev=0 --tags)"
+echo "New deployment: ${new_tag}"
+
+if [[ -f "${version_file}" ]]; # only remove the version file if it exists
+then
+    rm $version_file 
+fi
+
+echo "${new_tag}" >> ./.version # write the new tag to the version file
+
+# only commit the new version file it is has actually changed
+# this will work since we reset against the HEAD at beginning
 if [[ -n $(git status --short) ]];
 then
-    
+    git add .version
+    git commit -m --author=${author_string} "Version number for deployment ${new_tag} [${new_tag_date}]"
+    git push --force origin HEAD # this is a dangerous force push, but I like to live life on the edge
+
+    git fetch && git checkout ${production_branch}
+    git merge origin ${source_branch} # merge source branch (i.e. master) into production
+    git commit -m --author=${author_string} "New deployment ${new_tag} [${new_tag_date}]"
+    git push --force origin ${production_branch} # another dangerous force push
 fi
+
+echo "Deployment finished."

--- a/tasks/deploy.sh
+++ b/tasks/deploy.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [[ -n $(git status --short) ]];
+then
+    
+fi


### PR DESCRIPTION
Closes #32 .

There are some new additions here:

1. A new Composer script `composer deploy`. This just runs the `./tasks/deploy.sh` script.
2. `./tasks/deploy.sh` will update the .version file check for any unstaged files, automatically commit them with a message and then tag a new release. The tag will be the same as the version file.
3. It will then checkout `production`, merge in master and commit for a new deployment.
4. Netlify will then pick up the `production` changes and start a new build. The version file will be included in the footer to clearly mark the current version (useful for checking issues, etc).