### PR TITLE
Always add rel noopener noreferrer to links

### DIFF
--- a/app/Markdown/Parser.php
+++ b/app/Markdown/Parser.php
@@ -10,6 +10,8 @@ use League\CommonMark\CommonMarkConverter;
 use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
 use Spatie\CommonMarkHighlighter\IndentedCodeRenderer;
 use League\CommonMark\Environment;
+use League\CommonMark\Inline\Element\Link;
+use RyanChandler\Markdown\Renderers\LinkRenderer;
 use TightenCo\Jigsaw\Parsers\JigsawMarkdownParser;
 
 class Parser extends MarkdownParser
@@ -35,6 +37,7 @@ class Parser extends MarkdownParser
     protected static function createCommonmark()
     {
         $environment = Environment::createCommonMarkEnvironment()
+            ->addInlineRenderer(Link::class, new LinkRenderer)
             ->addBlockRenderer(FencedCode::class, new FencedCodeRenderer(static::$languages))
             ->addBlockRenderer(IndentedCode::class, new IndentedCodeRenderer(static::$languages));
 

--- a/app/Markdown/Renderers/LinkRenderer.php
+++ b/app/Markdown/Renderers/LinkRenderer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace RyanChandler\Markdown\Renderers;
+
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Inline\Renderer\LinkRenderer as BaseLinkRenderer;
+use League\CommonMark\Util\ConfigurationInterface;
+use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\ElementRendererInterface;
+
+class LinkRenderer implements InlineRendererInterface, ConfigurationAwareInterface
+{
+    /**
+     * @var ConfigurationInterface
+     */
+    protected $config;
+
+    /**
+     * @var \League\CommonMark\Inline\Renderer\LinkRenderer
+     */
+    protected $baseLinkRenderer;
+
+    public function __construct()
+    {
+        $this->baseLinkRenderer = new BaseLinkRenderer;
+    }
+
+    /**
+     * @param Link                     $inline
+     * @param ElementRendererInterface $htmlRenderer
+     *
+     * @return HtmlElement
+     */
+    public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
+    {
+        $inline->data['attributes']['target'] = '_blank';
+        
+        $this->baseLinkRenderer->setConfiguration($this->config);
+        
+        return $this->baseLinkRenderer->render($inline, $htmlRenderer);
+    }
+
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->config = $configuration;
+    }
+}


### PR DESCRIPTION
Closes #29 . This is a bit of a hacky implementation since it will make all links that get parsed `target="_blank"`, but I'm fine with this since I'd always want people to have my article open to come back.

It also uses the `LinkRenderer` provided with `league/commonmark` so that any changes to that get applied to this project too. It's not extending that though since the class is `final` 👎🏻

Either way, it works and is more secure.